### PR TITLE
Fix proxy_port logic

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -99,7 +99,7 @@ class crowdstrike (
       } else {
         if (
           ($current_proxy_host != $proxy_host) or
-          ($current_proxy_port != $proxy_port) or
+          (String($current_proxy_port) != String($proxy_port)) or
           ($current_proxy_disable == true)
         ) {
           # if proxy is disabled, but has to be enabled or host/port have changed


### PR DESCRIPTION
Currently, if proxy_port is set, Puppet will rerun falconctl every run,
as the proxy_port fact is a string, but proxy_port from hiera is a
Stdlib::Port, and the comparison is always non-equal

This patch ensures that the check to see if we need to rerun falconctl
will compare String with String