### PR TITLE
fix fact if falcon_facts is nil

### DIFF
--- a/lib/facter/falcon_sensor.rb
+++ b/lib/facter/falcon_sensor.rb
@@ -50,7 +50,7 @@ Facter.add(:falcon_sensor) do
         nil
       end
       # do not include unset values in the fact
-      falcon_facts.reject { |_, value| value.nil? }
+      (falcon_facts || {}).reject { |_, value| value.nil? }
     else
       nil
     end


### PR DESCRIPTION
Hello,

If falcon_facts is nil the fact fail:
Error: Facter: error while resolving custom fact "falcon_sensor": undefined method `reject' for nil:NilClass

Regards,