### PR TITLE
Update Gemfile to Voxpupuli recommended content and deprecate Puppet 6.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,73 +1,26 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
-def location_for(place_or_version, fake_version = nil)
-  git_url_regex = %r{\A(?<url>(https?|git)[:@][^#]*)(#(?<branch>.*))?}
-  file_url_regex = %r{\Afile:\/\/(?<path>.*)}
-
-  if place_or_version && (git_url = place_or_version.match(git_url_regex))
-    [fake_version, { git: git_url[:url], branch: git_url[:branch], require: false }].compact
-  elsif place_or_version && (file_url = place_or_version.match(file_url_regex))
-    ['>= 0', { path: File.expand_path(file_url[:path]), require: false }]
-  else
-    [place_or_version, { require: false }]
-  end
-end
-
 group :development do
-  gem "json", '= 2.1.0',                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.3.0',                         require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.5.1',                         require: false if Gem::Requirement.create(['>= 3.0.0', '< 3.0.5']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.6.1',                         require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.6.3',                         require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "racc", '~> 1.4.0',                        require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "voxpupuli-puppet-lint-plugins", '~> 5.0', require: false
-  gem "facterdb", '~> 1.18',                     require: false
-  gem "metadata-json-lint", '~> 3.0',            require: false
-  gem "puppetlabs_spec_helper", '~> 6.0',        require: false
-  gem "rspec-puppet-facts", '~> 2.0',            require: false
-  gem "codecov", '~> 0.2',                       require: false
-  gem "dependency_checker", '~> 1.0.0',          require: false
-  gem "parallel_tests", '= 3.12.1',              require: false
-  gem "pry", '~> 0.10',                          require: false
-  gem "simplecov-console", '~> 0.5',             require: false
-  gem "puppet-debugger", '~> 1.0',               require: false
-  gem "rubocop", '= 1.48.1',                     require: false
-  gem "rubocop-performance", '= 1.16.0',         require: false
-  gem "rubocop-rspec", '= 2.19.0',               require: false
-  gem "rb-readline", '= 0.5.5',                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
-end
-group :system_tests do
-  gem "puppet_litmus", '~> 1.0', require: false, platforms: [:ruby, :x64_mingw]
-  gem "serverspec", '~> 2.41',   require: false
 end
 
-puppet_version = ENV['PUPPET_GEM_VERSION']
-facter_version = ENV['FACTER_GEM_VERSION']
-hiera_version = ENV['HIERA_GEM_VERSION']
+# The test group is used for static validations and unit tests in gha-puppet's
+# basic and beaker gha-puppet workflows.
+group :test do
+  # Require the latest Puppet by default unless a specific version was requested
+  # CI will typically set it to '~> 7.0' to get 7.x
+  gem 'puppet', ENV.fetch('PUPPET_GEM_VERSION', '>= 0'), require: false
 
-gems = {}
+  # Needed to build the test matrix based on metadata
+  gem 'puppet_metadata', '~> 3.4', require: false
 
-gems['puppet'] = location_for(puppet_version)
+  # Needed for the rake tasks
+  gem 'puppetlabs_spec_helper', '>= 2.16.0', '< 7', require: false
 
-# If facter or hiera versions have been specified via the environment
-# variables
+  # Rubocop versions are also specific so it's recommended
+  # to be precise. Can be turned off via a parameter
+  gem 'rubocop', require: false
+  gem 'rubocop-performance', require: false
 
-gems['facter'] = location_for(facter_version) if facter_version
-gems['hiera'] = location_for(hiera_version) if hiera_version
-
-gems.each do |gem_name, gem_params|
-  gem gem_name, *gem_params
+  # metagem that pulls in all further requirements
+  gem 'voxpupuli-test', '~> 7.0', require: false
 end
-
-# Evaluate Gemfile.local and ~/.gemfile if they exist
-extra_gemfiles = [
-  "#{__FILE__}.local",
-  File.join(Dir.home, '.gemfile'),
-]
-
-extra_gemfiles.each do |gemfile|
-  if File.file?(gemfile) && File.readable?(gemfile)
-    eval(File.read(gemfile), binding)
-  end
-end
-# vim: syntax=ruby

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -38,16 +38,16 @@ class { '::crowdstrike':
 
 The following parameters are available in the `crowdstrike` class:
 
-* [`ensure`](#ensure)
-* [`cid`](#cid)
-* [`provisioning_token`](#provisioning_token)
-* [`tags`](#tags)
-* [`proxy_host`](#proxy_host)
-* [`proxy_port`](#proxy_port)
-* [`package_source`](#package_source)
-* [`package_provider`](#package_provider)
+* [`ensure`](#-crowdstrike--ensure)
+* [`cid`](#-crowdstrike--cid)
+* [`provisioning_token`](#-crowdstrike--provisioning_token)
+* [`tags`](#-crowdstrike--tags)
+* [`proxy_host`](#-crowdstrike--proxy_host)
+* [`proxy_port`](#-crowdstrike--proxy_port)
+* [`package_source`](#-crowdstrike--package_source)
+* [`package_provider`](#-crowdstrike--package_provider)
 
-##### <a name="ensure"></a>`ensure`
+##### <a name="-crowdstrike--ensure"></a>`ensure`
 
 Data type: `Enum['present','absent','latest']`
 
@@ -56,59 +56,59 @@ When set to `absent` uninstalls the agent's package.
 
 Default value: `'present'`
 
-##### <a name="cid"></a>`cid`
+##### <a name="-crowdstrike--cid"></a>`cid`
 
 Data type: `Optional[Variant[String, Deferred]]`
 
 Customer IDentifier. Necessary to register the agent with the service. Mandatory.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="provisioning_token"></a>`provisioning_token`
+##### <a name="-crowdstrike--provisioning_token"></a>`provisioning_token`
 
 Data type: `Optional[Variant[String, Deferred]]`
 
 Provisioning token for the crowdstrike agent installation.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="tags"></a>`tags`
+##### <a name="-crowdstrike--tags"></a>`tags`
 
 Data type: `Optional[Array[String]]`
 
 Array of string tags used to group agents in the CrowdStrike console.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="proxy_host"></a>`proxy_host`
+##### <a name="-crowdstrike--proxy_host"></a>`proxy_host`
 
 Data type: `Optional[String]`
 
 Proxy server host name for proxied connections. Mandatory if `proxy_port` is specified.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="proxy_port"></a>`proxy_port`
+##### <a name="-crowdstrike--proxy_port"></a>`proxy_port`
 
 Data type: `Optional[Stdlib::Port]`
 
 Proxy server port for proxied connections. Mandatory if `proxy_host` is specified.
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="package_source"></a>`package_source`
+##### <a name="-crowdstrike--package_source"></a>`package_source`
 
 Data type: `Optional[String]`
 
 Define a package source for installation
 
-Default value: ``undef``
+Default value: `undef`
 
-##### <a name="package_provider"></a>`package_provider`
+##### <a name="-crowdstrike--package_provider"></a>`package_provider`
 
 Data type: `Optional[String]`
 
 Define a package provider for installation
 
-Default value: ``undef``
+Default value: `undef`
 

--- a/metadata.json
+++ b/metadata.json
@@ -62,10 +62,10 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.21.0 < 8.0.0"
+      "version_requirement": ">= 7.0.0 < 8.0.0"
     }
   ],
-  "pdk-version": "3.0.0",
-  "template-url": "pdk-default#3.0.0",
-  "template-ref": "tags/3.0.0-0-g056e50d"
+  "pdk-version": "3.0.1",
+  "template-url": "pdk-default#3.0.1",
+  "template-ref": "tags/3.0.1-0-gd13288a"
 }


### PR DESCRIPTION
Puppet 6 is now deprecated along with the Ruby 2.5 tests.

In addition, update the Gemfile to Voxpupuli-recommended content.